### PR TITLE
Fixed an bug where its possible to submit order twice

### DIFF
--- a/view/frontend/web/template/payment/advance_payment.html
+++ b/view/frontend/web/template/payment/advance_payment.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/alipay.html
+++ b/view/frontend/web/template/payment/alipay.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/barzahlen.html
+++ b/view/frontend/web/template/payment/barzahlen.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/billsafe.html
+++ b/view/frontend/web/template/payment/billsafe.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/cash_on_delivery.html
+++ b/view/frontend/web/template/payment/cash_on_delivery.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/creditcard.html
+++ b/view/frontend/web/template/payment/creditcard.html
@@ -151,7 +151,7 @@
                         data-bind="
                         click: handleCreditcardPayment,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/debit.html
+++ b/view/frontend/web/template/payment/debit.html
@@ -110,7 +110,7 @@
                         data-bind="
                         click: (isManageMandateActive() == 1 ? handleDebitPayment : placeOrder),
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/invoice.html
+++ b/view/frontend/web/template/payment/invoice.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/klarna.html
+++ b/view/frontend/web/template/payment/klarna.html
@@ -220,7 +220,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/obt_eps.html
+++ b/view/frontend/web/template/payment/obt_eps.html
@@ -76,7 +76,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/obt_giropay.html
+++ b/view/frontend/web/template/payment/obt_giropay.html
@@ -91,7 +91,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/obt_ideal.html
+++ b/view/frontend/web/template/payment/obt_ideal.html
@@ -76,7 +76,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/obt_postfinance_card.html
+++ b/view/frontend/web/template/payment/obt_postfinance_card.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/obt_postfinance_efinance.html
+++ b/view/frontend/web/template/payment/obt_postfinance_efinance.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/obt_przelewy.html
+++ b/view/frontend/web/template/payment/obt_przelewy.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/obt_sofortueberweisung.html
+++ b/view/frontend/web/template/payment/obt_sofortueberweisung.html
@@ -93,7 +93,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/paydirekt.html
+++ b/view/frontend/web/template/payment/paydirekt.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/payolution_debit.html
+++ b/view/frontend/web/template/payment/payolution_debit.html
@@ -159,7 +159,7 @@
                         data-bind="
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/payolution_installment.html
+++ b/view/frontend/web/template/payment/payolution_installment.html
@@ -162,7 +162,7 @@
                         data-bind="
                         click: placeOrder,
                         attr: {id: getCode() + '_submit', title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/payolution_invoice.html
+++ b/view/frontend/web/template/payment/payolution_invoice.html
@@ -130,7 +130,7 @@
                         data-bind="
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/paypal.html
+++ b/view/frontend/web/template/payment/paypal.html
@@ -54,7 +54,7 @@
                         data-bind="
                         click: continueToPayone,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>

--- a/view/frontend/web/template/payment/safe_invoice.html
+++ b/view/frontend/web/template/payment/safe_invoice.html
@@ -99,7 +99,7 @@
                         data-bind="
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
+                        enable: (getCode() == isChecked() && isPlaceOrderActionAllowed()),
                         css: {disabled: !isPlaceOrderActionAllowed()}
                         "
                         disabled>


### PR DESCRIPTION
With an IE11 its possible to submit the checkout form twice (if you click more then once). The problem is nearly not reproducible because its only possible for a few milliseconds.

The same Problem was in an earlier Magento version and was fixed with MAGETWO-72351.

To fix it the data-bind of the Submit Button was changed so that the enable state checks also the isPlaceOrderActionAllowed function.